### PR TITLE
use interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7",
-    "phpspec/prophecy": "dev-patch-1 as 1.6.2",
+    "phpspec/prophecy": "^1.7",
     "prooph/php-cs-fixer-config": "^0.1.1",
     "satooshi/php-coveralls": "^1.0",
     "psr/container": "^1.0",
@@ -88,11 +88,5 @@
     "test": "phpunit",
     "test-coverage": "phpunit --coverage-clover build/logs/clover.xml",
     "docs": "bookdown docs/bookdown.json"
-  },
-  "repositories": [
-    {
-      "type": "git",
-      "url": "https://github.com/prolic/prophecy.git"
-    }
-  ]
+  }
 }

--- a/src/Response/ResponseStrategy.php
+++ b/src/Response/ResponseStrategy.php
@@ -18,12 +18,12 @@ use React\Promise\PromiseInterface;
 /**
  * Generate HTTP response depending on Promise result data
  *
- * This is an example how to generate a JsonResponse from a React\Promise\Promise
+ * This is an example how to generate a JsonResponse from a React\Promise\PromiseInterface
  *
  * <code>
  * final class JsonResponse implements ResponseStrategy
  * {
- *     public function fromPromise(\React\Promise\Promise $promise)
+ *     public function fromPromise(\React\Promise\PromiseInterface $promise)
  *     {
  *         $data = null;
  *

--- a/src/Response/ResponseStrategy.php
+++ b/src/Response/ResponseStrategy.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace Prooph\Psr7Middleware\Response;
 
 use Psr\Http\Message\ResponseInterface;
-use React\Promise\Promise;
+use React\Promise\PromiseInterface;
 
 /**
  * Generate HTTP response depending on Promise result data
@@ -38,5 +38,5 @@ use React\Promise\Promise;
  */
 interface ResponseStrategy
 {
-    public function fromPromise(Promise $promise): ResponseInterface;
+    public function fromPromise(PromiseInterface $promise): ResponseInterface;
 }


### PR DESCRIPTION
I noticed the [Interface](https://github.com/prooph/psr7-middleware/blob/develop/src/Response/ResponseStrategy.php#L41) for the response strategy is of a concrete type whist interfaces exists. So I set about to change it.

```
interface ResponseStrategy
{
    public function fromPromise(PromiseInterface $promise): ResponseInterface;
}
```

But then I noticed that the [`PromiseInterface`](https://github.com/prooph/proophessor-do/blob/master/src/Response/JsonResponse.php#L21
) only contains a `then` method. However I think that is not an issue as the react/promise has merged the two interface for an upcoming release https://github.com/reactphp/promise/commit/d91c9303473ede9ba4d7ff3489d499b2438764b7

