### PR TITLE
Improvement/psr15 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,8 +44,8 @@
     "prooph/service-bus" : "^6.0",
     "psr/http-message": "^1.0",
     "react/promise" : "^2.2",
-    "http-interop/http-middleware": "^0.4.1",
-    "fig/http-message-util": "^1.1"
+    "fig/http-message-util": "^1.1",
+    "webimpress/http-middleware-compatibility": "^0.1.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.0",
@@ -56,7 +56,8 @@
     "sandrokeil/interop-config": "^2.0.1",
     "prooph/bookdown-template": "^0.2.3",
     "zendframework/zend-servicemanager": "^3.1",
-    "malukenho/docheader": "^0.1.4"
+    "malukenho/docheader": "^0.1.4",
+    "http-interop/http-middleware": "^0.5.0"
   },
   "suggest": {
     "psr/container": "^1.0 for usage of provided factories",

--- a/src/CommandMiddleware.php
+++ b/src/CommandMiddleware.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 namespace Prooph\Psr7Middleware;
 
 use Fig\Http\Message\StatusCodeInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use Prooph\Common\Messaging\MessageFactory;
 use Prooph\Psr7Middleware\Exception\RuntimeException;
 use Prooph\Psr7Middleware\Response\ResponseStrategy;
 use Prooph\ServiceBus\CommandBus;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 
 /**
  * Command messages describe actions your model can handle.

--- a/src/CommandMiddleware.php
+++ b/src/CommandMiddleware.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 namespace Prooph\Psr7Middleware;
 
 use Fig\Http\Message\StatusCodeInterface;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use Prooph\Common\Messaging\MessageFactory;
 use Prooph\Psr7Middleware\Exception\RuntimeException;
 use Prooph\Psr7Middleware\Response\ResponseStrategy;
@@ -76,7 +76,7 @@ final class CommandMiddleware implements MiddlewareInterface
         $this->responseStrategy = $responseStrategy;
     }
 
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, HandlerInterface $handler)
     {
         $commandName = $request->getAttribute(self::NAME_ATTRIBUTE);
 

--- a/src/EventMiddleware.php
+++ b/src/EventMiddleware.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 namespace Prooph\Psr7Middleware;
 
 use Fig\Http\Message\StatusCodeInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use Prooph\Common\Messaging\MessageFactory;
 use Prooph\Psr7Middleware\Exception\RuntimeException;
 use Prooph\Psr7Middleware\Response\ResponseStrategy;
 use Prooph\ServiceBus\EventBus;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 
 /**
  * Event messages describe things that happened while your model handled a command.

--- a/src/EventMiddleware.php
+++ b/src/EventMiddleware.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 namespace Prooph\Psr7Middleware;
 
 use Fig\Http\Message\StatusCodeInterface;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use Prooph\Common\Messaging\MessageFactory;
 use Prooph\Psr7Middleware\Exception\RuntimeException;
 use Prooph\Psr7Middleware\Response\ResponseStrategy;
@@ -76,7 +76,7 @@ final class EventMiddleware implements MiddlewareInterface
         $this->responseStrategy = $responseStrategy;
     }
 
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, HandlerInterface $handler)
     {
         $eventName = $request->getAttribute(self::NAME_ATTRIBUTE);
 

--- a/src/MessageMiddleware.php
+++ b/src/MessageMiddleware.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 namespace Prooph\Psr7Middleware;
 
 use Fig\Http\Message\StatusCodeInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageDataAssertion;
 use Prooph\Common\Messaging\MessageFactory;
@@ -25,6 +23,8 @@ use Prooph\ServiceBus\EventBus;
 use Prooph\ServiceBus\QueryBus;
 use Psr\Http\Message\ServerRequestInterface;
 use Ramsey\Uuid\Uuid;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 
 /**
  * One middleware for all message types (event, command and query)

--- a/src/MessageMiddleware.php
+++ b/src/MessageMiddleware.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 namespace Prooph\Psr7Middleware;
 
 use Fig\Http\Message\StatusCodeInterface;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageDataAssertion;
 use Prooph\Common\Messaging\MessageFactory;
@@ -82,7 +82,7 @@ final class MessageMiddleware implements MiddlewareInterface
         $this->responseStrategy = $responseStrategy;
     }
 
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, HandlerInterface $handler)
     {
         $payload = null;
         $messageName = 'UNKNOWN';

--- a/src/QueryMiddleware.php
+++ b/src/QueryMiddleware.php
@@ -14,13 +14,13 @@ namespace Prooph\Psr7Middleware;
 
 use Fig\Http\Message\RequestMethodInterface;
 use Fig\Http\Message\StatusCodeInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use Prooph\Common\Messaging\MessageFactory;
 use Prooph\Psr7Middleware\Exception\RuntimeException;
 use Prooph\Psr7Middleware\Response\ResponseStrategy;
 use Prooph\ServiceBus\QueryBus;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 
 /**
  * Query messages describe available information that can be fetched from your (read) model.

--- a/src/QueryMiddleware.php
+++ b/src/QueryMiddleware.php
@@ -14,8 +14,8 @@ namespace Prooph\Psr7Middleware;
 
 use Fig\Http\Message\RequestMethodInterface;
 use Fig\Http\Message\StatusCodeInterface;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use Prooph\Common\Messaging\MessageFactory;
 use Prooph\Psr7Middleware\Exception\RuntimeException;
 use Prooph\Psr7Middleware\Response\ResponseStrategy;
@@ -79,7 +79,7 @@ final class QueryMiddleware implements MiddlewareInterface
         $this->metadataGatherer = $metadataGatherer;
     }
 
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, HandlerInterface $handler)
     {
         $queryName = $request->getAttribute(self::NAME_ATTRIBUTE);
 

--- a/tests/CommandMiddlewareTest.php
+++ b/tests/CommandMiddlewareTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\Psr7Middleware;
 
 use Fig\Http\Message\StatusCodeInterface;
-use Interop\Http\ServerMiddleware\DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageFactory;
@@ -50,14 +50,14 @@ class CommandMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->withStatus()->shouldNotBeCalled();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
+        $handler = $this->prophesize(HandlerInterface::class);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(sprintf('Command name attribute ("%s") was not found in request.', CommandMiddleware::NAME_ATTRIBUTE));
 
         $middleware = new CommandMiddleware($commandBus->reveal(), $messageFactory->reveal(), $gatherer->reveal(), $responseStrategy->reveal());
 
-        $middleware->process($request->reveal(), $delegate->reveal());
+        $middleware->process($request->reveal(), $handler->reveal());
     }
 
     /**
@@ -92,7 +92,7 @@ class CommandMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->withStatus()->shouldNotBeCalled();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
+        $handler = $this->prophesize(HandlerInterface::class);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionCode(StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR);
@@ -100,7 +100,7 @@ class CommandMiddlewareTest extends TestCase
 
         $middleware = new CommandMiddleware($commandBus->reveal(), $messageFactory->reveal(), $gatherer->reveal(), $responseStrategy->reveal());
 
-        $middleware->process($request->reveal(), $delegate->reveal());
+        $middleware->process($request->reveal(), $handler->reveal());
     }
 
     /**
@@ -137,9 +137,9 @@ class CommandMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->withStatus(StatusCodeInterface::STATUS_ACCEPTED)->willReturn($response);
 
-        $delegate = $this->prophesize(DelegateInterface::class);
+        $handler = $this->prophesize(HandlerInterface::class);
 
         $middleware = new CommandMiddleware($commandBus->reveal(), $messageFactory->reveal(), $gatherer->reveal(), $responseStrategy->reveal());
-        $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $delegate->reveal()));
+        $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $handler->reveal()));
     }
 }

--- a/tests/CommandMiddlewareTest.php
+++ b/tests/CommandMiddlewareTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace ProophTest\Psr7Middleware;
 
 use Fig\Http\Message\StatusCodeInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageFactory;
@@ -25,6 +24,7 @@ use Prooph\ServiceBus\CommandBus;
 use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 
 /**
  * Test integrity of \Prooph\Psr7Middleware\CommandMiddleware

--- a/tests/EventMiddlewareTest.php
+++ b/tests/EventMiddlewareTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\Psr7Middleware;
 
 use Fig\Http\Message\StatusCodeInterface;
-use Interop\Http\ServerMiddleware\DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageFactory;
@@ -50,14 +50,14 @@ class EventMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->withStatus()->shouldNotBeCalled();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
+        $handler = $this->prophesize(HandlerInterface::class);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(sprintf('Event name attribute ("%s") was not found in request.', EventMiddleware::NAME_ATTRIBUTE));
 
         $middleware = new EventMiddleware($eventBus->reveal(), $messageFactory->reveal(), $gatherer->reveal(), $responseStrategy->reveal());
 
-        $middleware->process($request->reveal(), $delegate->reveal());
+        $middleware->process($request->reveal(), $handler->reveal());
     }
 
     /**
@@ -93,7 +93,7 @@ class EventMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->withStatus()->shouldNotBeCalled();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
+        $handler = $this->prophesize(HandlerInterface::class);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionCode(StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR);
@@ -101,7 +101,7 @@ class EventMiddlewareTest extends TestCase
 
         $middleware = new EventMiddleware($eventBus->reveal(), $messageFactory->reveal(), $gatherer->reveal(), $responseStrategy->reveal());
 
-        $middleware->process($request->reveal(), $delegate->reveal());
+        $middleware->process($request->reveal(), $handler->reveal());
     }
 
     /**
@@ -138,9 +138,9 @@ class EventMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->withStatus(StatusCodeInterface::STATUS_ACCEPTED)->willReturn($response);
 
-        $delegate = $this->prophesize(DelegateInterface::class);
+        $handler = $this->prophesize(HandlerInterface::class);
 
         $middleware = new EventMiddleware($eventBus->reveal(), $messageFactory->reveal(), $gatherer->reveal(), $responseStrategy->reveal());
-        $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $delegate->reveal()));
+        $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $handler->reveal()));
     }
 }

--- a/tests/EventMiddlewareTest.php
+++ b/tests/EventMiddlewareTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace ProophTest\Psr7Middleware;
 
 use Fig\Http\Message\StatusCodeInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageFactory;
@@ -25,6 +24,7 @@ use Prooph\ServiceBus\EventBus;
 use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 
 /**
  * Test integrity of \Prooph\Psr7Middleware\EventMiddleware

--- a/tests/MessageMiddlewareTest.php
+++ b/tests/MessageMiddlewareTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace ProophTest\Psr7Middleware;
 
 use Fig\Http\Message\StatusCodeInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageFactory;
@@ -27,6 +26,7 @@ use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Promise\Promise;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 
 /**
  * Test integrity of \Prooph\Psr7Middleware\MessageMiddleware

--- a/tests/MessageMiddlewareTest.php
+++ b/tests/MessageMiddlewareTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\Psr7Middleware;
 
 use Fig\Http\Message\StatusCodeInterface;
-use Interop\Http\ServerMiddleware\DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageFactory;
@@ -58,7 +58,7 @@ class MessageMiddlewareTest extends TestCase
         $request->getParsedBody()->willReturn(['message_name' => 'test'])->shouldBeCalled();
         $request->getAttribute('message_name', 'test')->willReturn('test')->shouldBeCalled();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
+        $handler = $this->prophesize(HandlerInterface::class);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('MessageData must contain a key payload');
@@ -71,7 +71,7 @@ class MessageMiddlewareTest extends TestCase
             $responseStrategy->reveal()
         );
 
-        $middleware->process($request->reveal(), $delegate->reveal());
+        $middleware->process($request->reveal(), $handler->reveal());
     }
 
     /**
@@ -110,7 +110,7 @@ class MessageMiddlewareTest extends TestCase
         $request->getParsedBody()->willReturn($payload)->shouldBeCalled();
         $request->getAttribute('message_name', 'unknown')->willReturn('unknown')->shouldBeCalled();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
+        $handler = $this->prophesize(HandlerInterface::class);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('An error occurred during dispatching of message "unknown"');
@@ -123,7 +123,7 @@ class MessageMiddlewareTest extends TestCase
             $responseStrategy->reveal()
         );
 
-        $middleware->process($request->reveal(), $delegate->reveal());
+        $middleware->process($request->reveal(), $handler->reveal());
     }
 
     public function providerMessageTypes(): array
@@ -196,7 +196,7 @@ class MessageMiddlewareTest extends TestCase
         $request->getParsedBody()->willReturn($payload)->shouldBeCalled();
         $request->getAttribute('message_name', 'name.' . $messageType)->willReturn('name.' . $messageType)->shouldBeCalled();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
+        $handler = $this->prophesize(HandlerInterface::class);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionCode(StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR);
@@ -209,7 +209,7 @@ class MessageMiddlewareTest extends TestCase
             $responseStrategy->reveal()
         );
 
-        $middleware->process($request->reveal(), $delegate->reveal());
+        $middleware->process($request->reveal(), $handler->reveal());
     }
 
     /**
@@ -249,7 +249,7 @@ class MessageMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->withStatus(StatusCodeInterface::STATUS_ACCEPTED)->willReturn($response);
 
-        $delegate = $this->prophesize(DelegateInterface::class);
+        $handler = $this->prophesize(HandlerInterface::class);
 
         $middleware = new MessageMiddleware(
             $commandBus->reveal(),
@@ -258,7 +258,7 @@ class MessageMiddlewareTest extends TestCase
             $messageFactory->reveal(),
             $responseStrategy->reveal()
         );
-        $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $delegate->reveal()));
+        $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $handler->reveal()));
     }
 
     /**
@@ -298,7 +298,7 @@ class MessageMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->withStatus(StatusCodeInterface::STATUS_ACCEPTED)->willReturn($response);
 
-        $delegate = $this->prophesize(DelegateInterface::class);
+        $handler = $this->prophesize(HandlerInterface::class);
 
         $middleware = new MessageMiddleware(
             $commandBus->reveal(),
@@ -307,7 +307,7 @@ class MessageMiddlewareTest extends TestCase
             $messageFactory->reveal(),
             $responseStrategy->reveal()
         );
-        $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $delegate->reveal()));
+        $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $handler->reveal()));
     }
 
     /**
@@ -349,7 +349,7 @@ class MessageMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->fromPromise(Argument::type(Promise::class))->willReturn($response);
 
-        $delegate = $this->prophesize(DelegateInterface::class);
+        $handler = $this->prophesize(HandlerInterface::class);
 
         $middleware = new MessageMiddleware(
             $commandBus->reveal(),
@@ -358,7 +358,7 @@ class MessageMiddlewareTest extends TestCase
             $messageFactory->reveal(),
             $responseStrategy->reveal()
         );
-        $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $delegate->reveal()));
+        $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $handler->reveal()));
     }
 
     /**
@@ -400,7 +400,7 @@ class MessageMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->withStatus(StatusCodeInterface::STATUS_ACCEPTED)->willReturn($response);
 
-        $delegate = $this->prophesize(DelegateInterface::class);
+        $handler = $this->prophesize(HandlerInterface::class);
 
         $middleware = new MessageMiddleware(
             $commandBus->reveal(),
@@ -409,7 +409,7 @@ class MessageMiddlewareTest extends TestCase
             $messageFactory->reveal(),
             $responseStrategy->reveal()
         );
-        $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $delegate->reveal()));
+        $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $handler->reveal()));
     }
 
     /**
@@ -457,7 +457,7 @@ class MessageMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->withStatus(StatusCodeInterface::STATUS_ACCEPTED)->willReturn($response);
 
-        $delegate = $this->prophesize(DelegateInterface::class);
+        $handler = $this->prophesize(HandlerInterface::class);
 
         $middleware = new MessageMiddleware(
             $commandBus->reveal(),
@@ -466,7 +466,7 @@ class MessageMiddlewareTest extends TestCase
             $messageFactory->reveal(),
             $responseStrategy->reveal()
         );
-        $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $delegate->reveal()));
+        $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $handler->reveal()));
     }
 
     /**

--- a/tests/QueryMiddlewareTest.php
+++ b/tests/QueryMiddlewareTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace ProophTest\Psr7Middleware;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageFactory;
@@ -50,14 +50,14 @@ class QueryMiddlewareTest extends TestCase
         $gatherer = $this->prophesize(MetadataGatherer::class);
         $gatherer->getFromRequest($request->reveal())->shouldNotBeCalled();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
+        $handler = $this->prophesize(HandlerInterface::class);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(sprintf('Query name attribute ("%s") was not found in request.', QueryMiddleware::NAME_ATTRIBUTE));
 
         $middleware = new QueryMiddleware($queryBus->reveal(), $messageFactory->reveal(), $responseStrategy->reveal(), $gatherer->reveal());
 
-        $middleware->process($request->reveal(), $delegate->reveal());
+        $middleware->process($request->reveal(), $handler->reveal());
     }
 
     /**
@@ -95,14 +95,14 @@ class QueryMiddlewareTest extends TestCase
         $gatherer = $this->prophesize(MetadataGatherer::class);
         $gatherer->getFromRequest($request->reveal())->willReturn([])->shouldBeCalled();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
+        $handler = $this->prophesize(HandlerInterface::class);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('An error occurred during dispatching of query "stdClass"');
 
         $middleware = new QueryMiddleware($queryBus->reveal(), $messageFactory->reveal(), $responseStrategy->reveal(), $gatherer->reveal());
 
-        $middleware->process($request->reveal(), $delegate->reveal());
+        $middleware->process($request->reveal(), $handler->reveal());
     }
 
     /**
@@ -142,11 +142,11 @@ class QueryMiddlewareTest extends TestCase
         $gatherer = $this->prophesize(MetadataGatherer::class);
         $gatherer->getFromRequest($request)->shouldBeCalled();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
+        $handler = $this->prophesize(HandlerInterface::class);
 
         $middleware = new QueryMiddleware($queryBus->reveal(), $messageFactory->reveal(), $responseStrategy->reveal(), $gatherer->reveal());
 
-        $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $delegate->reveal()));
+        $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $handler->reveal()));
     }
 
     /**
@@ -188,10 +188,10 @@ class QueryMiddlewareTest extends TestCase
         $gatherer = $this->prophesize(MetadataGatherer::class);
         $gatherer->getFromRequest($request)->shouldBeCalled();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
+        $handler = $this->prophesize(HandlerInterface::class);
 
         $middleware = new QueryMiddleware($queryBus->reveal(), $messageFactory->reveal(), $responseStrategy->reveal(), $gatherer->reveal());
 
-        $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $delegate->reveal()));
+        $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $handler->reveal()));
     }
 }

--- a/tests/QueryMiddlewareTest.php
+++ b/tests/QueryMiddlewareTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace ProophTest\Psr7Middleware;
 
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageFactory;
@@ -25,6 +24,7 @@ use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Promise\Promise;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 
 /**
  * Test integrity of \Prooph\Psr7Middleware\QueryMiddleware


### PR DESCRIPTION
#27 

- [http-interop/http-middleware](https://github.com/http-interop/http-middleware),
  which provides the interfaces that will become PSR-15. In Prooph,
  this is pinned to the ^0.4 series. Now you have to explicitly define an
  http-interop/http-middleware dependency in your `composer.json`, and you can
  use any version which is currently supported by the polyfill package
  [webimpress/http-middleware-compatibility](https://github.com/webimpress/http-middleware-compatibility).
