### PR TITLE
use psr/http-server-middleware (PSR-15) interfaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "psr/http-message": "^1.0",
     "react/promise" : "^2.2",
     "fig/http-message-util": "^1.1",
-    "webimpress/http-middleware-compatibility": "^0.1.4"
+    "http-interop/http-server-middleware": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.0",
@@ -56,8 +56,7 @@
     "sandrokeil/interop-config": "^2.0.1",
     "prooph/bookdown-template": "^0.2.3",
     "zendframework/zend-servicemanager": "^3.1",
-    "malukenho/docheader": "^0.1.4",
-    "http-interop/http-middleware": "^0.5.0"
+    "malukenho/docheader": "^0.1.4"
   },
   "suggest": {
     "psr/container": "^1.0 for usage of provided factories",

--- a/src/CommandMiddleware.php
+++ b/src/CommandMiddleware.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 namespace Prooph\Psr7Middleware;
 
 use Fig\Http\Message\StatusCodeInterface;
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
 use Prooph\Common\Messaging\MessageFactory;
 use Prooph\Psr7Middleware\Exception\RuntimeException;
 use Prooph\Psr7Middleware\Response\ResponseStrategy;
 use Prooph\ServiceBus\CommandBus;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 
 /**
  * Command messages describe actions your model can handle.
@@ -76,7 +77,7 @@ final class CommandMiddleware implements MiddlewareInterface
         $this->responseStrategy = $responseStrategy;
     }
 
-    public function process(ServerRequestInterface $request, HandlerInterface $handler)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $commandName = $request->getAttribute(self::NAME_ATTRIBUTE);
 

--- a/src/EventMiddleware.php
+++ b/src/EventMiddleware.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 namespace Prooph\Psr7Middleware;
 
 use Fig\Http\Message\StatusCodeInterface;
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
 use Prooph\Common\Messaging\MessageFactory;
 use Prooph\Psr7Middleware\Exception\RuntimeException;
 use Prooph\Psr7Middleware\Response\ResponseStrategy;
 use Prooph\ServiceBus\EventBus;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 
 /**
  * Event messages describe things that happened while your model handled a command.
@@ -76,7 +77,7 @@ final class EventMiddleware implements MiddlewareInterface
         $this->responseStrategy = $responseStrategy;
     }
 
-    public function process(ServerRequestInterface $request, HandlerInterface $handler)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $eventName = $request->getAttribute(self::NAME_ATTRIBUTE);
 

--- a/src/MessageMiddleware.php
+++ b/src/MessageMiddleware.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 namespace Prooph\Psr7Middleware;
 
 use Fig\Http\Message\StatusCodeInterface;
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageDataAssertion;
 use Prooph\Common\Messaging\MessageFactory;
@@ -21,10 +23,9 @@ use Prooph\Psr7Middleware\Response\ResponseStrategy;
 use Prooph\ServiceBus\CommandBus;
 use Prooph\ServiceBus\EventBus;
 use Prooph\ServiceBus\QueryBus;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Ramsey\Uuid\Uuid;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 
 /**
  * One middleware for all message types (event, command and query)
@@ -82,7 +83,7 @@ final class MessageMiddleware implements MiddlewareInterface
         $this->responseStrategy = $responseStrategy;
     }
 
-    public function process(ServerRequestInterface $request, HandlerInterface $handler)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $payload = null;
         $messageName = 'UNKNOWN';

--- a/src/QueryMiddleware.php
+++ b/src/QueryMiddleware.php
@@ -14,13 +14,14 @@ namespace Prooph\Psr7Middleware;
 
 use Fig\Http\Message\RequestMethodInterface;
 use Fig\Http\Message\StatusCodeInterface;
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
 use Prooph\Common\Messaging\MessageFactory;
 use Prooph\Psr7Middleware\Exception\RuntimeException;
 use Prooph\Psr7Middleware\Response\ResponseStrategy;
 use Prooph\ServiceBus\QueryBus;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 
 /**
  * Query messages describe available information that can be fetched from your (read) model.
@@ -79,7 +80,7 @@ final class QueryMiddleware implements MiddlewareInterface
         $this->metadataGatherer = $metadataGatherer;
     }
 
-    public function process(ServerRequestInterface $request, HandlerInterface $handler)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $queryName = $request->getAttribute(self::NAME_ATTRIBUTE);
 

--- a/tests/CommandMiddlewareTest.php
+++ b/tests/CommandMiddlewareTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\Psr7Middleware;
 
 use Fig\Http\Message\StatusCodeInterface;
+use Interop\Http\Server\RequestHandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageFactory;
@@ -24,7 +25,6 @@ use Prooph\ServiceBus\CommandBus;
 use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 
 /**
  * Test integrity of \Prooph\Psr7Middleware\CommandMiddleware
@@ -50,7 +50,7 @@ class CommandMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->withStatus()->shouldNotBeCalled();
 
-        $handler = $this->prophesize(HandlerInterface::class);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(sprintf('Command name attribute ("%s") was not found in request.', CommandMiddleware::NAME_ATTRIBUTE));
@@ -92,7 +92,7 @@ class CommandMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->withStatus()->shouldNotBeCalled();
 
-        $handler = $this->prophesize(HandlerInterface::class);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionCode(StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR);
@@ -137,7 +137,7 @@ class CommandMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->withStatus(StatusCodeInterface::STATUS_ACCEPTED)->willReturn($response);
 
-        $handler = $this->prophesize(HandlerInterface::class);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
 
         $middleware = new CommandMiddleware($commandBus->reveal(), $messageFactory->reveal(), $gatherer->reveal(), $responseStrategy->reveal());
         $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $handler->reveal()));

--- a/tests/EventMiddlewareTest.php
+++ b/tests/EventMiddlewareTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\Psr7Middleware;
 
 use Fig\Http\Message\StatusCodeInterface;
+use Interop\Http\Server\RequestHandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageFactory;
@@ -24,7 +25,6 @@ use Prooph\ServiceBus\EventBus;
 use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 
 /**
  * Test integrity of \Prooph\Psr7Middleware\EventMiddleware
@@ -50,7 +50,7 @@ class EventMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->withStatus()->shouldNotBeCalled();
 
-        $handler = $this->prophesize(HandlerInterface::class);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(sprintf('Event name attribute ("%s") was not found in request.', EventMiddleware::NAME_ATTRIBUTE));
@@ -93,7 +93,7 @@ class EventMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->withStatus()->shouldNotBeCalled();
 
-        $handler = $this->prophesize(HandlerInterface::class);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionCode(StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR);
@@ -138,7 +138,7 @@ class EventMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->withStatus(StatusCodeInterface::STATUS_ACCEPTED)->willReturn($response);
 
-        $handler = $this->prophesize(HandlerInterface::class);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
 
         $middleware = new EventMiddleware($eventBus->reveal(), $messageFactory->reveal(), $gatherer->reveal(), $responseStrategy->reveal());
         $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $handler->reveal()));

--- a/tests/MessageMiddlewareTest.php
+++ b/tests/MessageMiddlewareTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\Psr7Middleware;
 
 use Fig\Http\Message\StatusCodeInterface;
+use Interop\Http\Server\RequestHandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageFactory;
@@ -26,7 +27,6 @@ use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Promise\Promise;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 
 /**
  * Test integrity of \Prooph\Psr7Middleware\MessageMiddleware
@@ -58,7 +58,7 @@ class MessageMiddlewareTest extends TestCase
         $request->getParsedBody()->willReturn(['message_name' => 'test'])->shouldBeCalled();
         $request->getAttribute('message_name', 'test')->willReturn('test')->shouldBeCalled();
 
-        $handler = $this->prophesize(HandlerInterface::class);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('MessageData must contain a key payload');
@@ -110,7 +110,7 @@ class MessageMiddlewareTest extends TestCase
         $request->getParsedBody()->willReturn($payload)->shouldBeCalled();
         $request->getAttribute('message_name', 'unknown')->willReturn('unknown')->shouldBeCalled();
 
-        $handler = $this->prophesize(HandlerInterface::class);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('An error occurred during dispatching of message "unknown"');
@@ -196,7 +196,7 @@ class MessageMiddlewareTest extends TestCase
         $request->getParsedBody()->willReturn($payload)->shouldBeCalled();
         $request->getAttribute('message_name', 'name.' . $messageType)->willReturn('name.' . $messageType)->shouldBeCalled();
 
-        $handler = $this->prophesize(HandlerInterface::class);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionCode(StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR);
@@ -249,7 +249,7 @@ class MessageMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->withStatus(StatusCodeInterface::STATUS_ACCEPTED)->willReturn($response);
 
-        $handler = $this->prophesize(HandlerInterface::class);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
 
         $middleware = new MessageMiddleware(
             $commandBus->reveal(),
@@ -298,7 +298,7 @@ class MessageMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->withStatus(StatusCodeInterface::STATUS_ACCEPTED)->willReturn($response);
 
-        $handler = $this->prophesize(HandlerInterface::class);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
 
         $middleware = new MessageMiddleware(
             $commandBus->reveal(),
@@ -349,7 +349,7 @@ class MessageMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->fromPromise(Argument::type(Promise::class))->willReturn($response);
 
-        $handler = $this->prophesize(HandlerInterface::class);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
 
         $middleware = new MessageMiddleware(
             $commandBus->reveal(),
@@ -400,7 +400,7 @@ class MessageMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->withStatus(StatusCodeInterface::STATUS_ACCEPTED)->willReturn($response);
 
-        $handler = $this->prophesize(HandlerInterface::class);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
 
         $middleware = new MessageMiddleware(
             $commandBus->reveal(),
@@ -457,7 +457,7 @@ class MessageMiddlewareTest extends TestCase
         $responseStrategy = $this->prophesize(ResponseStrategy::class);
         $responseStrategy->withStatus(StatusCodeInterface::STATUS_ACCEPTED)->willReturn($response);
 
-        $handler = $this->prophesize(HandlerInterface::class);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
 
         $middleware = new MessageMiddleware(
             $commandBus->reveal(),

--- a/tests/QueryMiddlewareTest.php
+++ b/tests/QueryMiddlewareTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace ProophTest\Psr7Middleware;
 
+use Interop\Http\Server\RequestHandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageFactory;
@@ -24,7 +25,6 @@ use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Promise\Promise;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 
 /**
  * Test integrity of \Prooph\Psr7Middleware\QueryMiddleware
@@ -50,7 +50,7 @@ class QueryMiddlewareTest extends TestCase
         $gatherer = $this->prophesize(MetadataGatherer::class);
         $gatherer->getFromRequest($request->reveal())->shouldNotBeCalled();
 
-        $handler = $this->prophesize(HandlerInterface::class);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(sprintf('Query name attribute ("%s") was not found in request.', QueryMiddleware::NAME_ATTRIBUTE));
@@ -95,7 +95,7 @@ class QueryMiddlewareTest extends TestCase
         $gatherer = $this->prophesize(MetadataGatherer::class);
         $gatherer->getFromRequest($request->reveal())->willReturn([])->shouldBeCalled();
 
-        $handler = $this->prophesize(HandlerInterface::class);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('An error occurred during dispatching of query "stdClass"');
@@ -142,7 +142,7 @@ class QueryMiddlewareTest extends TestCase
         $gatherer = $this->prophesize(MetadataGatherer::class);
         $gatherer->getFromRequest($request)->shouldBeCalled();
 
-        $handler = $this->prophesize(HandlerInterface::class);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
 
         $middleware = new QueryMiddleware($queryBus->reveal(), $messageFactory->reveal(), $responseStrategy->reveal(), $gatherer->reveal());
 
@@ -188,7 +188,7 @@ class QueryMiddlewareTest extends TestCase
         $gatherer = $this->prophesize(MetadataGatherer::class);
         $gatherer->getFromRequest($request)->shouldBeCalled();
 
-        $handler = $this->prophesize(HandlerInterface::class);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
 
         $middleware = new QueryMiddleware($queryBus->reveal(), $messageFactory->reveal(), $responseStrategy->reveal(), $gatherer->reveal());
 


### PR DESCRIPTION
This PR 

- removes webimpress' middleware compatibility layer
- adds the final draft for http-server-middleware
- provides compatibility to current zend expressive ^3 branch.
- **BC-Break**